### PR TITLE
fix: correct default API port and remove --frozen from Dockerfile

### DIFF
--- a/contents/base/{{ prefix-name }}-{{ suffix-name }}/.github/workflows/integration-tests.yml
+++ b/contents/base/{{ prefix-name }}-{{ suffix-name }}/.github/workflows/integration-tests.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           # Use actual endpoint testing instead of Docker health checks
           for i in {1..36}; do  # 3 minutes max
-            if curl -s -f http://localhost:8080/health/live >/dev/null 2>&1; then
+            if curl -s -f http://localhost:8000/health/live >/dev/null 2>&1; then
               echo "✅ REST service is responding!"
               sleep 5  # Stabilization time
               break
@@ -117,7 +117,7 @@ jobs:
           done
           
           # Final verification
-          if ! curl -f http://localhost:8080/health/live; then
+          if ! curl -f http://localhost:8000/health/live; then
             echo "❌ Service failed to become ready"
             docker compose logs {{ prefix-name }}-{{ suffix-name }}
             exit 1
@@ -126,8 +126,8 @@ jobs:
       - name: Verify service health
         run: |
           # Check REST service health endpoints
-          curl -f http://localhost:8080/health/live
-          curl -f http://localhost:8080/health/ready
+          curl -f http://localhost:8000/health/live
+          curl -f http://localhost:8000/health/ready
           
           # Check main API endpoint
           curl -f http://localhost:8000/
@@ -152,7 +152,7 @@ jobs:
           API_SERVER_HOST: localhost
           API_SERVER_PORT: 8000
           MANAGEMENT_SERVER_HOST: localhost
-          MANAGEMENT_SERVER_PORT: 8080
+          MANAGEMENT_SERVER_PORT: 8000
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/{{ prefix_name }}_{{ suffix_name }}
           PYTHONPATH: ${{'{'}}{github.workspace}}
       
@@ -270,7 +270,7 @@ jobs:
           
           # Wait for server to start with proper endpoint testing
           for i in {1..20}; do  # 2 minutes max
-            if curl -s -f http://localhost:8080/health/live >/dev/null 2>&1; then
+            if curl -s -f http://localhost:8000/health/live >/dev/null 2>&1; then
               echo "✅ REST server started successfully"
               break
             fi
@@ -279,7 +279,7 @@ jobs:
           done
           
           # Final verification
-          if ! curl -f http://localhost:8080/health/live; then
+          if ! curl -f http://localhost:8000/health/live; then
             echo "Server failed to start, logs:"
             cat server.log
             exit 1
@@ -287,7 +287,7 @@ jobs:
         env:
           DATABASE_URL: postgresql+asyncpg://postgres:testpass@localhost:5432/{{ prefix_name }}_{{ suffix_name }}_rest_test
           API_PORT: 8000
-          MANAGEMENT_PORT: 8080
+          MANAGEMENT_PORT: 8000
       
       - name: Test client connectivity
         run: |
@@ -332,7 +332,7 @@ jobs:
           API_SERVER_HOST: localhost
           API_SERVER_PORT: 8000
           MANAGEMENT_SERVER_HOST: localhost
-          MANAGEMENT_SERVER_PORT: 8080
+          MANAGEMENT_SERVER_PORT: 8000
           DATABASE_URL: postgresql+asyncpg://postgres:testpass@localhost:5432/{{ prefix_name }}_{{ suffix_name }}_rest_test
       
       - name: Cleanup REST server
@@ -371,7 +371,7 @@ jobs:
       - name: Wait for service readiness
         run: |
           for i in {1..36}; do  # 3 minutes max
-            if curl -s -f http://localhost:8080/health/live >/dev/null 2>&1; then
+            if curl -s -f http://localhost:8000/health/live >/dev/null 2>&1; then
               echo "✅ Service ready for performance testing!"
               sleep 5
               break
@@ -394,7 +394,7 @@ jobs:
           API_SERVER_HOST: localhost
           API_SERVER_PORT: 8000
           MANAGEMENT_SERVER_HOST: localhost
-          MANAGEMENT_SERVER_PORT: 8080
+          MANAGEMENT_SERVER_PORT: 8000
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/{{ prefix_name }}_{{ suffix_name }}
       
       - name: Cleanup

--- a/contents/base/{{ prefix-name }}-{{ suffix-name }}/Dockerfile
+++ b/contents/base/{{ prefix-name }}-{{ suffix-name }}/Dockerfile
@@ -38,8 +38,8 @@ COPY {{ prefix-name }}-{{ suffix-name }}-server/src ./{{ prefix-name }}-{{ suffi
 # Copy scripts
 COPY scripts ./scripts
 
-# Install dependencies
-RUN uv sync --frozen --no-dev
+# Install dependencies (generates lockfile if not present)
+RUN uv sync --no-dev
 
 # Production stage
 FROM python:3.11-slim as production
@@ -74,7 +74,7 @@ EXPOSE 8000 8080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost:8080/health/live || exit 1
+    CMD curl -f http://localhost:8000/health/live || exit 1
 
 # Default command  
 CMD ["python", "-m", "{{ org_name }}.{{ solution_name }}.{{ prefix_name }}.{{ suffix_name }}.server.main"]

--- a/contents/base/{{ prefix-name }}-{{ suffix-name }}/docker-compose.yml
+++ b/contents/base/{{ prefix-name }}-{{ suffix-name }}/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health/live"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health/live"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/contents/base/{{ prefix-name }}-{{ suffix-name }}/{{ prefix-name }}-{{ suffix-name }}-server/src/{{ org_name }}/{{ solution_name }}/{{ prefix_name }}/{{ suffix_name }}/server/config/settings.py
+++ b/contents/base/{{ prefix-name }}-{{ suffix-name }}/{{ prefix-name }}-{{ suffix-name }}-server/src/{{ org_name }}/{{ solution_name }}/{{ prefix_name }}/{{ suffix_name }}/server/config/settings.py
@@ -37,7 +37,7 @@ class Settings(BaseSettings):
         description="Host to bind the API server"
     )
     api_port: int = Field(
-        default=8080,
+        default=8000,
         description="Port to bind the API server"
     )
     


### PR DESCRIPTION
Additional fixes for the archetype:

1. settings.py: Change default api_port from 8080 to 8000
   - The REST API should run on port 8000 by default

2. Dockerfile:
   - Change healthcheck from 8080 to 8000
   - Remove --frozen flag from uv sync (archetype doesn't generate lockfile)

3. docker-compose.yml: Change healthcheck from 8080 to 8000

4. integration-tests.yml: Update all health check URLs and MANAGEMENT_SERVER_PORT from 8080 to 8000

These fixes ensure the generated project works out of the box without port configuration mismatches.